### PR TITLE
Fix multiple terminal states bug from bmdp format

### DIFF
--- a/src/Data/bmdp-tool.jl
+++ b/src/Data/bmdp-tool.jl
@@ -27,6 +27,7 @@ function read_bmdp_tool_file(path)
     open(path, "r") do io
         number_states = read_intline(readline(io))
         number_actions = read_intline(readline(io))
+        _ = readline(io)
         terminal_states = read_intline.(split(readline(io))) .+ Int32(1)
 
         probs = Vector{


### PR DESCRIPTION
Fixes a bug in reading the terminal states from the "bmdp" file format. Previously errored on Line 33 if more than 1 terminal state was present.