### PR TITLE
Unify value function

### DIFF
--- a/ext/cuda/value_iteration.jl
+++ b/ext/cuda/value_iteration.jl
@@ -15,7 +15,6 @@ function IntervalMDP.step_imdp!(
     value_function::IntervalMDP.IMDPValueFunction;
     maximize,
     upper_bound,
-    discount = 1.0,
 ) where {R, VR <: AbstractVector{R}, MR <: CuSparseMatrixCSC{R}}
     ominmax!(
         ordering,
@@ -26,7 +25,6 @@ function IntervalMDP.step_imdp!(
     )
 
     value_function.action_values .= Transpose(value_function.prev_transpose * p)
-    rmul!(value_function.action_values, discount)
 
     V_per_state =
         CuVectorOfVector(stateptr, value_function.action_values, maximum(diff(stateptr)))
@@ -36,7 +34,6 @@ function IntervalMDP.step_imdp!(
     @cuda blocks = blocks threads = threads extremum_vov_kernel!(
         value_function.cur,
         V_per_state,
-        discount,
         maximize,
     )
 
@@ -46,7 +43,6 @@ end
 function extremum_vov_kernel!(
     V::CuDeviceVector{Tv, A},
     V_per_state::CuDeviceVectorOfVector{Tv, Ti, A},
-    discount,
     maximize,
 ) where {Tv, Ti, A}
     j = blockIdx().x
@@ -83,7 +79,6 @@ function extremum_vov_kernel!(
             i += blockDim().x
         end
 
-        V[j] *= discount
         j += gridDim().x
     end
 end

--- a/ext/cuda/value_iteration.jl
+++ b/ext/cuda/value_iteration.jl
@@ -16,13 +16,7 @@ function IntervalMDP.step_imdp!(
     maximize,
     upper_bound,
 ) where {R, VR <: AbstractVector{R}, MR <: CuSparseMatrixCSC{R}}
-    ominmax!(
-        ordering,
-        p,
-        prob,
-        value_function.prev;
-        max = upper_bound,
-    )
+    ominmax!(ordering, p, prob, value_function.prev; max = upper_bound)
 
     value_function.action_values .= Transpose(value_function.prev_transpose * p)
 

--- a/src/Data/bmdp-tool.jl
+++ b/src/Data/bmdp-tool.jl
@@ -180,7 +180,9 @@ function write_bmdp_tool_file(
     end
 end
 
-function write_bmdp_tool_file(path, mdp::IntervalMarkovChain, 
+function write_bmdp_tool_file(
+    path,
+    mdp::IntervalMarkovChain,
     terminal_states::Vector{T},
 ) where {T <: Integer}
     prob = transition_prob(mdp)

--- a/src/interval_probabilities.jl
+++ b/src/interval_probabilities.jl
@@ -47,10 +47,7 @@ end
 
 # Constructor from lower and gap with sanity assertions
 function IntervalProbabilities(lower::MR, gap::MR) where {R, MR <: AbstractMatrix{R}}
-    @assert all(lower .>= 0) "The lower bound transition probabilities must be non-negative."
-    @assert all(gap .>= 0) "The gap transition probabilities must be non-negative."
-    @assert all(gap .<= 1) "The gap transition probabilities must be less than or equal to 1."
-    @assert all(lower .+ gap .<= 1) "The sum of lower and gap transition probabilities must be less than or equal to 1."
+    checkprobabilities!(lower, gap)
 
     sum_lower = vec(sum(lower; dims = 1))
 
@@ -63,6 +60,20 @@ function IntervalProbabilities(lower::MR, gap::MR) where {R, MR <: AbstractMatri
     @assert max_upper_bound >= 1 "The joint upper bound transition probability per column (min is $max_upper_bound) should be greater than or equal to 1."
 
     return IntervalProbabilities(lower, gap, sum_lower)
+end
+
+function checkprobabilities!(lower::AbstractMatrix, gap::AbstractMatrix)
+    @assert all(lower .>= 0) "The lower bound transition probabilities must be non-negative."
+    @assert all(gap .>= 0) "The gap transition probabilities must be non-negative."
+    @assert all(gap .<= 1) "The gap transition probabilities must be less than or equal to 1."
+    @assert all(lower .+ gap .<= 1) "The sum of lower and gap transition probabilities must be less than or equal to 1."
+end
+
+function checkprobabilities!(lower::AbstractSparseMatrix, gap::AbstractSparseMatrix)
+    @assert all(nonzeros(lower) .>= 0) "The lower bound transition probabilities must be non-negative."
+    @assert all(nonzeros(gap) .>= 0) "The gap transition probabilities must be non-negative."
+    @assert all(nonzeros(gap) .<= 1) "The gap transition probabilities must be less than or equal to 1."
+    @assert all(nonzeros(lower) .+ nonzeros(gap) .<= 1) "The sum of lower and gap transition probabilities must be less than or equal to 1."
 end
 
 # Keyword constructor from lower and upper

--- a/src/specification.jl
+++ b/src/specification.jl
@@ -493,8 +493,10 @@ Specification(prop::Property) = Specification(prop, Pessimistic)
 Specification(prop::Property, satisfaction::SatisfactionMode) =
     Specification(prop, satisfaction, Maximize)
 
-initialize!(value_function, spec::Specification) = initialize!(value_function, system_property(spec))
-postprocess!(value_function, spec::Specification) = postprocess!(value_function, system_property(spec))
+initialize!(value_function, spec::Specification) =
+    initialize!(value_function, system_property(spec))
+postprocess!(value_function, spec::Specification) =
+    postprocess!(value_function, system_property(spec))
 
 function checkspecification!(spec::Specification, system)
     return checkproperty!(system_property(spec), system)

--- a/src/synthesis.jl
+++ b/src/synthesis.jl
@@ -87,13 +87,7 @@ function step_imdp_with_extract!(
 )
     sptr = stateptr(mdp)
 
-    ominmax!(
-        ordering,
-        p,
-        prob,
-        value_function.prev;
-        max = upper_bound,
-    )
+    ominmax!(ordering, p, prob, value_function.prev; max = upper_bound)
 
     optfun = maximize ? argmax : argmin
 
@@ -107,7 +101,7 @@ function step_imdp_with_extract!(
         @inbounds s2 = sptr[j + 1]
 
         @inbounds indices[j] =
-            optfun(view(value_function.action_values, s1:(s2 - 1)))  + s1 - 1
+            optfun(view(value_function.action_values, s1:(s2 - 1))) + s1 - 1
         @inbounds value_function.cur[j] = value_function.action_values[indices[j]]
     end
 

--- a/src/synthesis.jl
+++ b/src/synthesis.jl
@@ -24,24 +24,21 @@ end
 
 function extract_time_varying_policy(
     problem::Problem{M, S},
-) where {M <: IntervalMarkovDecisionProcess, S <: Specification{<:AbstractReachability}}
+) where {M <: IntervalMarkovDecisionProcess, S <: Specification}
     mdp = system(problem)
     spec = specification(problem)
-    prop = system_property(spec)
     term_criteria = termination_criteria(spec)
     upper_bound = satisfaction_mode(spec) == Optimistic
     maximize = strategy_mode(spec) == Maximize
 
     prob = transition_prob(mdp)
-    maxactions = maximum(diff(stateptr(mdp)))
-    target = reach(prop)
 
     # It is more efficient to use allocate first and reuse across iterations
     p = deepcopy(gap(prob))  # Deep copy as it may be a vector of vectors and we need sparse arrays to store the same indices
     ordering = construct_ordering(p)
 
     value_function = IMDPValueFunction(problem)
-    initialize!(value_function, target, 1.0)
+    initialize!(value_function, spec)
 
     policy = Vector{Vector{Int}}(undef, 1)
 
@@ -54,6 +51,7 @@ function extract_time_varying_policy(
         maximize = maximize,
         upper_bound = upper_bound,
     )
+    postprocess!(value_function, spec)
     policy[1] = step_policy
     k = 1
 
@@ -68,65 +66,7 @@ function extract_time_varying_policy(
             maximize = maximize,
             upper_bound = upper_bound,
         )
-        push!(policy, step_policy)
-        k += 1
-    end
-
-    # The policy vector is built starting from the target state
-    # at the final time step, so we need to reverse it.
-    return reverse(policy)
-end
-
-function extract_time_varying_policy(
-    problem::Problem{M, S},
-) where {M <: IntervalMarkovDecisionProcess, S <: Specification{<:AbstractReward}}
-    mdp = system(problem)
-    spec = specification(problem)
-    prop = system_property(spec)
-    term_criteria = termination_criteria(spec)
-    upper_bound = satisfaction_mode(spec) == Optimistic
-    maximize = strategy_mode(spec) == Maximize
-
-    prob = transition_prob(mdp)
-
-    # It is more efficient to use allocate first and reuse across iterations
-    p = deepcopy(gap(prob))  # Deep copy as it may be a vector of vectors and we need sparse arrays to store the same indices
-    ordering = construct_ordering(p)
-
-    value_function = IMDPValueFunction(problem)
-    initialize!(value_function, 1:num_states(mdp), reward(prop))
-
-    policy = Vector{Vector{Int}}(undef, 1)
-
-    step_policy = step_imdp_with_extract!(
-        ordering,
-        p,
-        mdp,
-        prob,
-        value_function;
-        maximize = maximize,
-        upper_bound = upper_bound,
-        discount = discount(prop),
-    )
-    # Add immediate reward
-    value_function.cur += reward(prop)
-    policy[1] = step_policy
-    k = 1
-
-    while !term_criteria(value_function.cur, k, lastdiff!(value_function))
-        nextiteration!(value_function)
-        step_policy = step_imdp_with_extract!(
-            ordering,
-            p,
-            mdp,
-            prob,
-            value_function;
-            maximize = maximize,
-            upper_bound = upper_bound,
-            discount = discount(prop),
-        )
-        # Add immediate reward
-        value_function.cur += reward(prop)
+        postprocess!(value_function, spec)
         push!(policy, step_policy)
         k += 1
     end
@@ -144,7 +84,6 @@ function step_imdp_with_extract!(
     value_function;
     maximize,
     upper_bound,
-    discount = 1.0,
 )
     sptr = stateptr(mdp)
 
@@ -159,7 +98,6 @@ function step_imdp_with_extract!(
     optfun = maximize ? argmax : argmin
 
     value_function.action_values .= Transpose(value_function.prev_transpose * p)
-    rmul!(value_function.action_values, discount)
 
     # Copy to ensure that terminal states are assigned their first (and only) action.
     indices = sptr[1:num_states(mdp)]

--- a/src/value_iteration.jl
+++ b/src/value_iteration.jl
@@ -90,14 +90,12 @@ function construct_value_function(::AbstractMatrix{R}, num_states) where {R}
 end
 
 mutable struct IMCValueFunction
-    prev
-    prev_transpose
-    cur
+    prev::Any
+    prev_transpose::Any
+    cur::Any
 end
 
-function IMCValueFunction(
-    problem::Problem{M, S},
-) where {M <: IntervalMarkovChain, S}
+function IMCValueFunction(problem::Problem{M, S}) where {M <: IntervalMarkovChain, S}
     mc = system(problem)
 
     prev = construct_value_function(gap(transition_prob(mc)), num_states(mc))
@@ -238,10 +236,10 @@ function value_iteration(
 end
 
 mutable struct IMDPValueFunction
-    prev
-    prev_transpose
-    cur
-    action_values
+    prev::Any
+    prev_transpose::Any
+    cur::Any
+    action_values::Any
 end
 
 function IMDPValueFunction(
@@ -254,12 +252,7 @@ function IMDPValueFunction(
 
     action_values = similar(prev, num_choices(mdp))
 
-    return IMDPValueFunction(
-        prev,
-        Transpose(prev),
-        cur,
-        action_values
-    )
+    return IMDPValueFunction(prev, Transpose(prev), cur, action_values)
 end
 
 function step_imdp!(
@@ -271,13 +264,7 @@ function step_imdp!(
     maximize,
     upper_bound,
 )
-    ominmax!(
-        ordering,
-        p,
-        prob,
-        value_function.prev;
-        max = upper_bound,
-    )
+    ominmax!(ordering, p, prob, value_function.prev; max = upper_bound)
 
     optfun = maximize ? maximum : minimum
 

--- a/test/cuda/vi.jl
+++ b/test/cuda/vi.jl
@@ -19,6 +19,13 @@ problem = Problem(mc, spec)
 V_fixed_it, k, _ = value_iteration(problem)
 @test k == 10
 
+prop = FiniteTimeReachability([3], 11)
+spec = Specification(prop, Pessimistic)
+problem = Problem(mc, spec)
+V_fixed_it2, k, _ = value_iteration(problem)
+@test k == 11
+@test all(V_fixed_it .<= V_fixed_it2)
+
 prop = InfiniteTimeReachability([3], 1e-6)
 spec = Specification(prop, Pessimistic)
 problem = Problem(mc, spec)

--- a/test/sparse/vi.jl
+++ b/test/sparse/vi.jl
@@ -19,6 +19,13 @@ problem = Problem(mc, spec)
 V_fixed_it, k, _ = value_iteration(problem)
 @test k == 10
 
+prop = FiniteTimeReachability([3], 11)
+spec = Specification(prop, Pessimistic)
+problem = Problem(mc, spec)
+V_fixed_it2, k, _ = value_iteration(problem)
+@test k == 11
+@test all(V_fixed_it .<= V_fixed_it2)
+
 prop = InfiniteTimeReachability([3], 1e-6)
 spec = Specification(prop, Pessimistic)
 problem = Problem(mc, spec)

--- a/test/vi.jl
+++ b/test/vi.jl
@@ -22,6 +22,13 @@ problem = Problem(mc, spec)
 V_fixed_it, k, _ = value_iteration(problem)
 @test k == 10
 
+prop = FiniteTimeReachability([3], 11)
+spec = Specification(prop, Pessimistic)
+problem = Problem(mc, spec)
+V_fixed_it2, k, _ = value_iteration(problem)
+@test k == 11
+@test all(V_fixed_it .<= V_fixed_it2)
+
 prop = InfiniteTimeReachability([3], 1e-6)
 spec = Specification(prop, Pessimistic)
 problem = Problem(mc, spec)


### PR DESCRIPTION
Until now, we had a separate value function for reach-avoid and for reward specifications (for each model type), which was a violation of DRY and more unmaintainable. With the introduction of the `postprocess!` function (called immediately after a value iteration step) in this PR, we can unify the two types of value functions (still separate for each model) and reduce the copies of the value iteration to maintain.

`postprocess!` does the following:

- For reachability, it assigns the reach set the value of 1.
- For reach-avoid, it assigns the reach set the value of 1 and the avoid set the value of 0.
- For a reward specification, it multiplies the current reward with the discount factor and adds the stepwise reward (in that order).

An additional benefit of this approach is that we decouple the specification and the system (again), since it no longer requires that the terminal set for reachability/reach-avoid only has a loop to itself (simplifying the safety checks introduced in #34).