### PR TITLE
Fix write/export intervalmdp model

### DIFF
--- a/src/Data/intervalmdp.jl
+++ b/src/Data/intervalmdp.jl
@@ -287,9 +287,10 @@ function _write_intervalmdp_jl_model(
         )
         v[:] = l.nzval + g.nzval
 
-        defDim(dataset, "stateptr", source_shape(marginal)[1] + 1)
+        num_source_states = source_shape(marginal)[1]
+        defDim(dataset, "stateptr", num_source_states + 1)
         v = defVar(dataset, "stateptr", Int32, ("stateptr",))
-        v[:] = [[Int32(1)]; (1:num_states(mdp)) .* Int32(num_actions(mdp)) .+ 1]
+        v[:] = [[Int32(1)]; (1:num_source_states) .* Int32(num_actions(mdp)) .+ 1]
 
         return nothing
     end


### PR DESCRIPTION
This fixes an error in write_intervalmdp_jl_model when saving models created via [IntervalMDPAbstraction](https://github.com/Zinoex/IntervalMDPAbstractions.jl). The resulting causes an size mismatch of 1, see below: 

`ERROR: LoadError: NetCDF error: size mismatch for variable 'stateptr' in file 'package_delivery.nc'. Trying to write (578,) elements while [577] are expected (NetCDF error code: -57)`